### PR TITLE
AWS CLI installation command

### DIFF
--- a/labs/0-installs.md
+++ b/labs/0-installs.md
@@ -158,6 +158,11 @@ pip --version
 pip install awscli
 ```
 
+Install AWS CLI for EL Capitan users:
+```bash
+sudo -H pip install awscli --upgrade --ignore-installed six
+```
+
 Python at least 2.6.5 or 3.x (recommended), see here: <http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html>. At <https://www.python.org/downloads/> you can download Python for your OS.
 
 

--- a/labs/0-installs.md
+++ b/labs/0-installs.md
@@ -158,7 +158,7 @@ pip --version
 pip install awscli
 ```
 
-AWS CLI installation command for EL Capitan users:
+AWS CLI installation command for El Capitan users:
 ```bash
 sudo -H pip install awscli --upgrade --ignore-installed six
 ```

--- a/labs/0-installs.md
+++ b/labs/0-installs.md
@@ -158,7 +158,7 @@ pip --version
 pip install awscli
 ```
 
-Install AWS CLI for EL Capitan users:
+AWS CLI installation command for EL Capitan users:
 ```bash
 sudo -H pip install awscli --upgrade --ignore-installed six
 ```


### PR DESCRIPTION
I just came into an issue to install AWS CLI on El Capitan OSX. And I found this solution:
https://github.com/aws/aws-cli/issues/1522#issuecomment-159007931